### PR TITLE
Fix TypeError when flags.core is nullish

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -209,7 +209,7 @@ Hooks.on("getJournalDirectoryEntryContext", (_html, contextEntries) => {
 				delete journalEntry.apps[sheet.appId];
 
 				// Toggle sheet class flag
-				if (journalEntry.data.flags.core.sheetClass === sheetClass) {
+				if (journalEntry.data.flags.core?.sheetClass === sheetClass) {
 					await journalEntry.setFlag("core", "sheetClass", "");
 				} else {
 					await journalEntry.setFlag("core", "sheetClass", sheetClass);


### PR DESCRIPTION
Resolves Error:
```
Uncaught (in promise) TypeError: Cannot read property 'sheetClass' of undefined
    at Object.callback (module.js:212)
```

Should be compatible with all major browsers - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

Otherwise, the classic `journalEntry.data.flags.core && journalEntry.data.flags.core.sheetClass === sheetClass` does the trick